### PR TITLE
chore: new logo; macos deploy; issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/mcp-report.yml
+++ b/.github/ISSUE_TEMPLATE/mcp-report.yml
@@ -1,0 +1,82 @@
+name: MCP 报告 / MCP Report
+description: 反馈 MCP/RV 的结果不符合预期、行为异常或能力缺失 / Report MCP/RV result mismatch, unexpected behavior, or missing capability
+title: "🧩[MCP] (标题这里简述一下，多个问题请取最重点的那个)"
+labels: ["mcp", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 🧩 MCP/RV 反馈说明(Report Guide)
+
+        感谢帮助我们改进 MCP/RV 体验。请尽量让每个 issue 聚焦一个问题，并提供足够信息，方便维护者复现、对比“当前现状”和“期待行为”。
+
+        Thanks for helping us improve MCP/RV. Please keep each issue focused on one problem, and include enough detail for maintainers to reproduce it and compare the observed result with the expected behavior.
+
+  - type: textarea
+    id: prompt
+    attributes:
+      label: 📝 Prompt 写了什么(Prompt / Request)
+      description: >-
+        请贴出当时写给 MCP/RV 的完整 prompt、命令或关键指令，尽量保留原文 / Paste the exact prompt,
+        command, or key instructions you gave to MCP/RV if possible
+      placeholder: |
+        例如 / Example:
+        "请使用 MCP ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-rv
+    attributes:
+      label: 👀 RV 现状(Current RV / Observed Result)
+      description: >-
+        请描述 RV 当前显示了什么、MCP 实际做了什么，以及哪里和 prompt 不一致。可以补充输出、截图、日志或错误信息 /
+        Describe what RV currently shows, what MCP actually did, and where it diverged from your prompt.
+        Include output, screenshots, logs, or errors if helpful
+      placeholder: |
+        例如 / Example:
+        - RV 当前显示：...
+        - MCP 实际执行：...
+        - 不符合预期的地方：...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: ✅ 期待行为(Expected Behavior)
+      description: >-
+        请具体说明你希望 MCP/RV 应该如何响应、展示或执行 / Describe as concretely as possible what
+        MCP/RV should have returned, displayed, or done instead
+      placeholder: |
+        例如 / Example:
+        - 应该展示：...
+        - 应该执行：...
+        - 理想结果：...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 🔁 复现与环境(Reproduction & Environment)
+      description: >-
+        可选但很有帮助。请补充复现步骤、MCP server/tool 名称、版本、系统、相关链接或其他环境信息 /
+        Optional but helpful. Add steps, MCP server/tool names, versions, OS, links, or other context
+        that helps reproduce the issue
+      placeholder: |
+        1. 打开 / Open ...
+        2. 输入 / Run ...
+        3. 观察 / Observe ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs-screenshots
+    attributes:
+      label: 📄 日志/截图/补充信息(Logs / Screenshots / Additional Context)
+      description: >-
+        如果有报错、日志、截图或其他补充信息，可以贴在这里；涉及隐私的信息请先打码 /
+        Paste errors, logs, screenshots, or any additional context here. Please redact private information
+    validations:
+      required: false

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -16,24 +16,7 @@ permissions:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            ext: .exe
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            ext: ''
-          # - os: macos-latest
-          #   target: aarch64-apple-darwin
-          #   ext: ''
-          # - os: ubuntu-22.04
-          #   target: x86_64-unknown-linux-gnu
-          #   ext: ''
-
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
 
     steps:
       - name: Checkout
@@ -42,7 +25,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: x86_64-pc-windows-msvc
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
@@ -67,55 +50,15 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli --locked
 
-      - name: Install Linux dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev \
-            rsync
-
-      # Two-Stage Build: Stage 1 (Installer) + Stage 2 (Bundle)
-      - name: Build (Windows)
-        if: runner.os == 'Windows'
+      - name: Build Windows desktop bundle
         shell: pwsh
         run: bun run desktop:pack
 
-      - name: Build (macOS/Linux)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          chmod +x deploy/scripts/build-desktop.sh
-          # Full build: Stage 1 (rvInstaller) + Stage 2 (app bundle)
-          ./deploy/scripts/build-desktop.sh --cross-target ${{ matrix.target }}
-
       # Artifact paths: Release builds output to __temp/tauri_dist
-      - name: Upload artifacts (Windows)
-        if: runner.os == 'Windows'
+      - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: rv-windows-${{ matrix.target }}
+          name: rv-windows-x86_64-pc-windows-msvc
+          if-no-files-found: error
           path: |
             __temp/tauri_dist/release/bundle/nsis/*.exe
-
-      - name: Upload artifacts (macOS)
-        if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
-        with:
-          name: rv-macos-${{ matrix.target }}
-          path: |
-            __temp/tauri_dist/release/bundle/dmg/*.dmg
-
-      - name: Upload artifacts (Linux)
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
-        with:
-          name: rv-linux-${{ matrix.target }}
-          path: |
-            __temp/tauri_dist/release/bundle/appimage/*.AppImage
-            __temp/tauri_dist/release/bundle/deb/*.deb

--- a/.github/workflows/optional-release-assets.yml
+++ b/.github/workflows/optional-release-assets.yml
@@ -1,0 +1,193 @@
+name: Build Optional Release Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing release tag to attach assets to (e.g. v1.0.0)'
+        required: true
+        type: string
+      source_ref:
+        description: 'Git ref to build. Leave empty to build the release tag.'
+        required: false
+        default: ''
+        type: string
+      target:
+        description: 'Non-Windows Rust target triple'
+        required: true
+        default: x86_64-apple-darwin
+        type: choice
+        options:
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+          - x86_64-unknown-linux-gnu
+      runner:
+        description: 'Runner label. Keep runner OS/architecture aligned with target.'
+        required: true
+        default: macos-15-intel
+        type: choice
+        options:
+          - macos-15-intel
+          - macos-latest
+          - ubuntu-22.04
+      upload_to_release:
+        description: 'Attach generated assets to the existing GitHub Release.'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  build-optional-assets:
+    name: Optional assets (${{ inputs.target }})
+    runs-on: ${{ inputs.runner }}
+
+    steps:
+      - name: Checkout source ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref || inputs.release_tag }}
+
+      - name: Display build context
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_REF: ${{ inputs.source_ref || inputs.release_tag }}
+          TARGET_TRIPLE: ${{ inputs.target }}
+          RUNNER_LABEL: ${{ inputs.runner }}
+        run: |
+          echo "Release tag: ${RELEASE_TAG}"
+          echo "Source ref: ${SOURCE_REF}"
+          echo "Target triple: ${TARGET_TRIPLE}"
+          echo "Runner label: ${RUNNER_LABEL}"
+
+      - name: Verify runner and target pairing
+        shell: bash
+        env:
+          TARGET_TRIPLE: ${{ inputs.target }}
+          RUNNER_LABEL: ${{ inputs.runner }}
+        run: |
+          runner_os="$(uname -s)"
+          runner_arch="$(uname -m)"
+
+          case "${TARGET_TRIPLE}" in
+            x86_64-apple-darwin)
+              expected_os="Darwin"
+              expected_arch="x86_64"
+              expected_runner="macos-15-intel"
+              ;;
+            aarch64-apple-darwin)
+              expected_os="Darwin"
+              expected_arch="arm64"
+              expected_runner="macos-latest"
+              ;;
+            x86_64-unknown-linux-gnu)
+              expected_os="Linux"
+              expected_arch="x86_64"
+              expected_runner="ubuntu-22.04"
+              ;;
+            *)
+              echo "::error::Unsupported optional target triple: ${TARGET_TRIPLE}"
+              exit 1
+              ;;
+          esac
+
+          if [ "${runner_os}" != "${expected_os}" ] || [ "${runner_arch}" != "${expected_arch}" ]; then
+            echo "::error::Runner ${runner_os}/${runner_arch} does not match target ${TARGET_TRIPLE}."
+            echo "::error::Expected ${expected_os}/${expected_arch} on ${expected_runner}."
+            exit 1
+          fi
+
+          if [ "${RUNNER_LABEL}" != "${expected_runner}" ]; then
+            echo "::error::Runner label ${RUNNER_LABEL} does not match target ${TARGET_TRIPLE}."
+            echo "::error::Use ${expected_runner} for ${TARGET_TRIPLE}."
+            exit 1
+          fi
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ inputs.target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: deploy/tauri
+          cache-targets: true
+          cache-all-crates: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: latest
+
+      - name: Install workspace dependencies
+        run: bun install
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            rsync
+
+      - name: Build optional desktop bundle
+        shell: bash
+        run: |
+          chmod +x deploy/scripts/build-desktop.sh
+          ./deploy/scripts/build-desktop.sh --cross-target ${{ inputs.target }}
+
+      - name: Upload optional workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rv-optional-${{ inputs.target }}
+          if-no-files-found: error
+          path: |
+            __temp/tauri_dist/release/bundle/dmg/*.dmg
+            __temp/tauri_dist/${{ inputs.target }}/release/bundle/dmg/*.dmg
+            __temp/tauri_dist/release/bundle/appimage/*.AppImage
+            __temp/tauri_dist/${{ inputs.target }}/release/bundle/appimage/*.AppImage
+            __temp/tauri_dist/release/bundle/deb/*.deb
+            __temp/tauri_dist/${{ inputs.target }}/release/bundle/deb/*.deb
+
+      - name: Attach optional assets to release
+        if: ${{ inputs.upload_to_release }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TARGET_TRIPLE: ${{ inputs.target }}
+        run: |
+          shopt -s nullglob
+          release_assets=(
+            "__temp/tauri_dist/release/bundle/dmg/"*.dmg
+            "__temp/tauri_dist/${TARGET_TRIPLE}/release/bundle/dmg/"*.dmg
+            "__temp/tauri_dist/release/bundle/appimage/"*.AppImage
+            "__temp/tauri_dist/${TARGET_TRIPLE}/release/bundle/appimage/"*.AppImage
+            "__temp/tauri_dist/release/bundle/deb/"*.deb
+            "__temp/tauri_dist/${TARGET_TRIPLE}/release/bundle/deb/"*.deb
+          )
+
+          if [ "${#release_assets[@]}" -eq 0 ]; then
+            echo "::error::No optional release assets found to upload."
+            exit 1
+          fi
+
+          gh release view "${RELEASE_TAG}" >/dev/null
+          gh release upload "${RELEASE_TAG}" "${release_assets[@]}" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,8 @@ jobs:
         body_path: full_body.md
         draft: true
         prerelease: ${{ steps.compose_notes.outputs.is_beta == 'true' }}
+        fail_on_unmatched_files: true
         files: |
           artifacts/**/*.exe
-          artifacts/**/*.dmg
-          artifacts/**/*.AppImage
-          artifacts/**/*.deb
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://rv.101114105.xyz" target="_blank">
-    <img src="https://img-cgs.101114105.xyz/file/rv/1769934512064_logo.png" alt="logo" height="156">
+    <img src="https://img-cgs.101114105.xyz/file/rv/1783438655018_rv-new-logo.png" alt="gif">
   </a>
   <h1 id="logo">redViewer(rV)</h1>
   <img src="https://img.shields.io/badge/Platform-Win%20|%20macOS%20|%20linux-blue?color=red" alt="tag">

--- a/deploy/scripts/build-desktop.sh
+++ b/deploy/scripts/build-desktop.sh
@@ -296,6 +296,26 @@ build_frontend() {
     echo "Frontend built successfully"
 }
 
+build_tauri_frontend() {
+    if [ "$SKIP_FRONTEND" = true ]; then
+        echo ""
+        echo "--- Skipping guide frontend build ---"
+        return
+    fi
+
+    echo ""
+    echo "--- Building Guide Frontend ---"
+    cd "$TAURI_DIR"
+
+    echo "Installing dependencies..."
+    bun install
+
+    echo "Building production bundle..."
+    bun run build
+
+    echo "Guide frontend built successfully"
+}
+
 copy_frontend_dist() {
     echo ""
     echo "--- Staging frontend dist ---"
@@ -476,6 +496,7 @@ if [[ "$TARGET" == "bundle" || "$TARGET" == "all" ]]; then
     # Stage 2 resources preparation
     copy_installer_to_stage
     build_frontend
+    build_tauri_frontend
     copy_frontend_dist
     copy_uv_binary
     copy_backend_source

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hero:
   text: 轻简风漫画阅读器
   tagline: 纳尼索咧, 一米哇嘎乃
   image:
-    src: /logo.png
+    src: https://img-cgs.101114105.xyz/file/rv/1783438655018_rv-new-logo.png
     alt: redViewer
   actions:
     - theme: brand


### PR DESCRIPTION
## Summary by Sourcery

将默认的桌面构建工作流限制为仅生成 Windows 工件，同时引入一个按需触发的独立工作流，用于构建并附加 macOS/Linux 可选资产，更新品牌资源，并新增一个用于 MCP 相关反馈的问题模板。

Enhancements:
- 将非 Windows 桌面构建包拆分到一个新的可选 workflow dispatch 任务中，该任务可为现有发布版本构建并上传 macOS 和 Linux 工件。
- 扩展桌面构建脚本，在现有前端流水线的基础上同时构建 Tauri 指南前端。

Build:
- 简化主桌面 CI 工作流，仅构建 Windows 目标并上传其 NSIS 安装程序工件，并收紧发布工作流，在引用的文件缺失时直接使其失败。

CI:
- 新增一个手动触发的工作流，可针对指定的标签构建非 Windows 发布包，并可选地将其上传到对应的 GitHub Release。

Documentation:
- 更新 README 和文档首页图片，使用新的托管 logo 资源。

Chores:
- 引入一个以 MCP 为重点的 GitHub Issue 模板，用于规范化 MCP/RV 行为问题的反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict the default desktop build workflow to Windows-only artifacts while introducing a separate on-demand workflow for building and attaching macOS/Linux optional assets, update branding assets, and add an issue template for MCP-related reports.

Enhancements:
- Separate non-Windows desktop bundles into a new optional workflow dispatch job that can build and upload macOS and Linux artifacts for an existing release.
- Extend the desktop build script to build the Tauri guide frontend alongside the existing frontend pipeline.

Build:
- Simplify the main desktop CI workflow to build only the Windows target and upload its NSIS installer artifact, and tighten the release workflow to fail when referenced files are missing.

CI:
- Add a manually triggered workflow that can build non-Windows release bundles for a specified tag and optionally upload them to the corresponding GitHub Release.

Documentation:
- Update README and docs hero image to use the new hosted logo asset.

Chores:
- Introduce an MCP-focused GitHub issue template to standardize reporting of MCP/RV behavior issues.

</details>